### PR TITLE
Improve entry delete

### DIFF
--- a/grails-app/jobs/errbuddy/DeleteEmptyGroupsJob.groovy
+++ b/grails-app/jobs/errbuddy/DeleteEmptyGroupsJob.groovy
@@ -12,9 +12,9 @@ class DeleteEmptyGroupsJob {
 //    }
 
 
-	def entryService
+	def entryGroupService
 
 	def perform() {
-		entryService.doDeleteEmpty()
+		entryGroupService.doDeleteEmpty()
 	}
 }

--- a/grails-app/jobs/errbuddy/DeleteEmptyGroupsJob.groovy
+++ b/grails-app/jobs/errbuddy/DeleteEmptyGroupsJob.groovy
@@ -2,15 +2,14 @@ package errbuddy
 
 class DeleteEmptyGroupsJob {
 
-//    static triggers = {
-//        // every 2 hours
-//        cron name: 'DeleteEmptyGroupsJob',
-//                jesqueJobName: DeleteEmptyGroupsJob.simpleName,
-//                jesqueQueue: "generic",
-//                cronExpression: "0 * * ? * * *",
-//                args: []
-//    }
-
+	static triggers = {
+		// 10 minutes after every hour
+		cron name: 'DeleteEmptyGroupsJob',
+			jesqueJobName: DeleteEmptyGroupsJob.simpleName,
+			jesqueQueue: "generic",
+			cronExpression: "0 10 * ? * * *",
+			args: []
+	}
 
 	def entryGroupService
 

--- a/grails-app/jobs/errbuddy/EntryDeleteJob.groovy
+++ b/grails-app/jobs/errbuddy/EntryDeleteJob.groovy
@@ -2,20 +2,10 @@ package errbuddy
 
 class EntryDeleteJob {
 
+	def entryService
+
 	def perform(Serializable id, boolean doCheckLatest = true) {
-
-		Entry entry = Entry.get(id)
-		if (!entry) {
-			return // looks like this was done already
-		}
-
-		if (doCheckLatest) {
-			EntryGroup.findByLatest(entry).each {
-				it.latest = null
-				it.save()
-			}
-		}
-		entry.delete()
+		entryService.delete(id, doCheckLatest)
 	}
 
 }

--- a/grails-app/services/errbuddy/EntryGroupService.groovy
+++ b/grails-app/services/errbuddy/EntryGroupService.groovy
@@ -158,6 +158,18 @@ class EntryGroupService {
 		}
 	}
 
+	void doDeleteEmpty() {
+		def groups = EntryGroup.createCriteria().list {
+			sizeEq('entries', 0)
+			lt('lastUpdated', DateTime.now().minusHours(2))
+			eq("collector", false)
+		}
+		groups.each { EntryGroup entryGroup ->
+			log.info("deleting $entryGroup.entryGroupId")
+			entryGroup.delete()
+		}
+	}
+
 	def doDeleteGroup(Serializable entryGroupId, boolean deleteEntries) {
 		EntryGroup toDelete = EntryGroup.get(entryGroupId)
 		App app = toDelete.app

--- a/grails-app/services/errbuddy/EntryService.groovy
+++ b/grails-app/services/errbuddy/EntryService.groovy
@@ -107,18 +107,6 @@ class EntryService {
 		}
 	}
 
-	void doDeleteEmpty() {
-		def groups = EntryGroup.createCriteria().list {
-			sizeEq('entries', 0)
-			lt('lastUpdated', DateTime.now().minusHours(2))
-			eq("collector", false)
-		}
-		groups.each { EntryGroup entryGroup ->
-			log.info("deleting $entryGroup.entryGroupId")
-			entryGroup.delete()
-		}
-	}
-
 	/**
 	 * Adds an entry to the collector group of the given Application and sets the refindSimilar flag
 	 * @param app

--- a/grails-app/services/errbuddy/EntryService.groovy
+++ b/grails-app/services/errbuddy/EntryService.groovy
@@ -162,6 +162,21 @@ class EntryService {
 		}
 	}
 
+	void delete(Serializable id, boolean doCheckLatest) {
+		Entry entry = Entry.get(id)
+		if (!entry) {
+			return // looks like this was done already
+		}
+
+		if (doCheckLatest) {
+			EntryGroup.findByLatest(entry).each {
+				it.latest = null
+				it.save()
+			}
+		}
+		entry.delete()
+	}
+
 	/**
 	 * Enqueues a new FindSimilarEntriesJob for all Entries that are in a collector group, and have the refindSimilar flag
 	 *


### PR DESCRIPTION
this MR contains 3 patches:
* moved `doDeleteEmpty` from entry to entryGroup service as it makes more sense there
* the `DeleteEmptyGroupsJob` has been revived: it runs 10 minutes after every hour
* made entry delete transactional by moving the code to the entry service